### PR TITLE
Add Alert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1570,8 +1570,7 @@
     "@types/prop-types": {
       "version": "15.7.3",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
-      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
-      "dev": true
+      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
     },
     "@types/qs": {
       "version": "6.9.1",
@@ -1582,10 +1581,17 @@
       "version": "16.9.23",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.23.tgz",
       "integrity": "sha512-SsGVT4E7L2wLN3tPYLiF20hmZTPGuzaayVunfgXzUn1x4uHVsKH6QDJQ/TdpHqwsTLd4CwrmQ2vOgxN7gE24gw==",
-      "dev": true,
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^2.2.0"
+      }
+    },
+    "@types/react-dom": {
+      "version": "16.9.6",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.6.tgz",
+      "integrity": "sha512-S6ihtlPMDotrlCJE9ST1fRmYrQNNwfgL61UB4I1W7M6kPulUKx9fXAleW5zpdIjUQ4fTaaog8uERezjsGUj9HQ==",
+      "requires": {
+        "@types/react": "*"
       }
     },
     "@types/react-native": {
@@ -2524,8 +2530,7 @@
     "csstype": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.9.tgz",
-      "integrity": "sha512-xz39Sb4+OaTsULgUERcCk+TJj8ylkL4aSVDQiX/ksxbELSqwkgt4d4RD7fovIdgJGSuNYqwZEiVjYY5l0ask+Q==",
-      "dev": true
+      "integrity": "sha512-xz39Sb4+OaTsULgUERcCk+TJj8ylkL4aSVDQiX/ksxbELSqwkgt4d4RD7fovIdgJGSuNYqwZEiVjYY5l0ask+Q=="
     },
     "date-fns": {
       "version": "2.11.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@types/base-64": "^0.1.3",
+    "@types/react-dom": "^16.9.6",
     "base-64": "^0.1.0",
     "date-fns": "^2.11.0",
     "expo": "~36.0.0",

--- a/src/EventEmitter.ts
+++ b/src/EventEmitter.ts
@@ -1,0 +1,41 @@
+/**
+ * A tiny event emitter class.
+ */
+class EventEmitter {
+  listeners = new Map<string, ((...args: any[]) => void)[]>();
+
+  /**
+   * Set up an event subscription.
+   *
+   * @param eventName The name of the event to subscribe to.
+   * @param callback Function to invoke when event is triggered.
+   * @returns A function which removes the subscription.
+   * @example eventEmitter.on("fileOpen", (file) => doThingWithFile(file));
+   */
+  on(eventName: string, callback: (...args: any[]) => void) {
+    const callbacks = this.listeners.get(eventName) || [];
+    callbacks.push(callback);
+    this.listeners.set(eventName, callbacks);
+
+    return () => {
+      const callbacks = this.listeners.get(eventName)!;
+      const idx = callbacks.indexOf(callback);
+      callbacks.splice(idx, 1);
+    };
+  }
+
+  /**
+   * Emit/invoke an event of a specific name with arguments.
+   * @param eventName The event to invoke.
+   * @param args Arguments to pass to event listeners.
+   * @example eventEmitter.emit("fileOpen", someFile);
+   */
+  emit(eventName: string, ...args: any[]) {
+    const callbacks = this.listeners.get(eventName) || [];
+    callbacks.forEach((callback) => {
+      callback(...args);
+    });
+  }
+}
+
+export default EventEmitter;

--- a/src/components/Alert.native.tsx
+++ b/src/components/Alert.native.tsx
@@ -1,0 +1,3 @@
+import { Alert } from "react-native";
+
+export default Alert;

--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -1,0 +1,209 @@
+/**
+ * This file is a web polyfill of React Native's Alert class.
+ * This module has the exact same API as React Native's Alert.
+ *
+ * How this works:
+ * 1. The first time Alert is imported, create a new React tree in
+ * another DOM node. We use a div with id "alert-root" appended to
+ * the body of the web page.
+ *
+ * 2. Set up an event subscription in AlertComponent. This is the
+ * React component of the alert itself that is displayed.
+ *
+ * 3. In Alert.alert and Alert.prompt, trigger events that will
+ * make AlertComponent render the alert.
+ */
+
+import React, { useEffect, useState } from "react";
+import {
+  AlertStatic,
+  AlertButton,
+  AlertOptions,
+  AlertType,
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+} from "react-native";
+import ReactDOM from "react-dom";
+import EventEmitter from "../EventEmitter";
+
+const alertEmitter = new EventEmitter();
+enum AlertEvent {
+  ShowAlert = "ShowAlert",
+  ShowPrompt = "ShowPrompt",
+}
+
+const styles = StyleSheet.create({
+  container: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: "rgba(0, 0, 0, 0.5)",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  alert: {
+    backgroundColor: "white",
+    width: "90%",
+    maxWidth: 500,
+    padding: 24,
+    borderRadius: 5,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: "bold",
+  },
+  message: {
+    fontSize: 16,
+    marginTop: 10,
+  },
+  buttonContainer: {
+    marginTop: 16,
+    flexDirection: "row",
+    justifyContent: "flex-end",
+  },
+  button: {
+    marginLeft: 16,
+  },
+  buttonLabel: {
+    color: "#2196f3",
+    fontSize: 16,
+    fontWeight: "bold",
+  },
+});
+
+type State =
+  | { show: "none" }
+  | {
+      show: "alert";
+      title: string;
+      message?: string;
+      buttons?: AlertButton[];
+      options?: AlertOptions;
+    };
+
+function AlertComponent() {
+  useEffect(() => {
+    const unsubAlert = alertEmitter.on(AlertEvent.ShowAlert, showAlert);
+    const unsubPrompt = alertEmitter.on(AlertEvent.ShowPrompt, showPrompt);
+
+    return () => {
+      unsubAlert();
+      unsubPrompt();
+    };
+  }, []);
+  const [state, setState] = useState<State>({ show: "none" });
+
+  function showAlert(
+    title: string,
+    message?: string,
+    buttons?: AlertButton[],
+    options?: AlertOptions
+  ) {
+    setState({
+      show: "alert",
+      title,
+      message,
+      buttons,
+      options,
+    });
+  }
+
+  function showPrompt() {
+    // Alert.prompt is not implemented on web. It seems to be an
+    // undocumented legacy(?) feature in React Native, and doesn't
+    // work on Android, so it should probably not be used anyway.
+    console.error("Alert.prompt not implemented on web.");
+  }
+
+  function dismissAndDo(callback?: () => void) {
+    setState({ show: "none" });
+    callback?.();
+  }
+
+  switch (state.show) {
+    case "none":
+      return null;
+    case "alert":
+      const { title, message, buttons } = state;
+
+      // Only support up to 3 buttons, similar to Android.
+      // If buttons are undefined, add a default "OK" button.
+      const validButtons =
+        buttons != null
+          ? buttons.slice(0, 3)
+          : [
+              {
+                text: "OK",
+              },
+            ];
+
+      return (
+        <View style={styles.container}>
+          <View style={styles.alert}>
+            <Text style={styles.title}>{title}</Text>
+            {message != null && <Text style={styles.message}>{message}</Text>}
+            <View style={styles.buttonContainer}>
+              {validButtons.map((btn, idx) => (
+                <TouchableOpacity
+                  key={idx}
+                  style={styles.button}
+                  onPress={() => dismissAndDo(btn.onPress)}
+                >
+                  <Text style={styles.buttonLabel}>{btn.text}</Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+          </View>
+        </View>
+      );
+  }
+}
+
+let hasInitialized = false;
+function initIfNeeded() {
+  if (hasInitialized) return;
+
+  const alertDomRoot = document.createElement("div");
+  alertDomRoot.id = "alert-root";
+  document.body.appendChild(alertDomRoot);
+
+  ReactDOM.render(<AlertComponent />, alertDomRoot);
+
+  hasInitialized = true;
+}
+initIfNeeded();
+
+const Alert: AlertStatic = {
+  alert(
+    title: string,
+    message?: string,
+    buttons?: AlertButton[],
+    options?: AlertOptions
+  ) {
+    alertEmitter.emit(AlertEvent.ShowAlert, title, message, buttons, options);
+  },
+  prompt(
+    title: string,
+    message?: string,
+    callbackOrButtons?: ((text: string) => void) | AlertButton[],
+    type?: AlertType,
+    defaultValue?: string,
+    keyboardType?: string
+  ) {
+    alertEmitter.emit(
+      AlertEvent.ShowPrompt,
+      title,
+      message,
+      callbackOrButtons,
+      type,
+      defaultValue,
+      keyboardType
+    );
+  },
+};
+
+export default Alert;


### PR DESCRIPTION
This pull request includes a working web implementation of React Native's Alert class.
To use, `import Alert from "./Alert"` instead of `import { Alert } from "react-native"`.

The usage is exactly the same as Alert from React Native.

If you're interested in how it works under the hood:
* Separate mobile and web implementation. The mobile implementation just re-exports Alert from react-native. The web implementation has exactly the same API.
* Web implementation renders a separate ReactDOM tree. Since the original API creates alerts imperatively (i.e., without rendering any React components), this was the best way I could figure out how to imperatively render new components without needing you to insert an "Alert root" component yourself. This would also be inconsistent with the native API.
* I set up an event system to which `AlertComponent` subscribes to so that the static method `Alert.alert` can influence the lifecycle of `AlertComponent`.

I have some additional comments in the code if you are interested in the implementation.

I had to install typings for react-dom to silence a TypeScript error.